### PR TITLE
MARSROVER-7: Add integration tests for /dailyPhoto endpoint

### DIFF
--- a/createServer.js
+++ b/createServer.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const createRoutes = require('./src/routes.js');
+
+function createServer() {
+    const app = express();
+    app.use(createRoutes());
+    return app;
+}
+
+module.exports = { createServer }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
-const express = require('express');
-const createRoutes = require('./src/routes.js');
+const { createServer } = require('./createServer.js')
 
-const app = express();
-const port = 3000;
+const PORT = 3000;
 
-app.use(createRoutes());
+const server = createServer();
 
-app.listen(port, () => {
-  console.log(`App listening at http://localhost:${port}`);
+server.listen(PORT, () => {
+  console.log(`App listening at http://localhost:${PORT}`);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3950,6 +3950,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -5063,6 +5069,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -7182,6 +7194,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -7429,6 +7447,35 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nock": {
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.11.tgz",
+      "integrity": "sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7583,6 +7630,12 @@
           }
         }
       }
+    },
+    "object-inspect": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -8042,6 +8095,12 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -8205,6 +8264,17 @@
             "p-limit": "^2.2.0"
           }
         }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -8836,6 +8906,17 @@
       "dev": true,
       "optional": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -9233,6 +9314,23 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -9284,6 +9382,87 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.3.tgz",
+      "integrity": "sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^6.1.0"
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -9726,6 +9905,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "utils-merge": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
     "husky": "^4.3.8",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.3",
+    "nock": "^13.0.11",
     "nodemon": "^2.0.7",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "supertest": "^6.1.3"
   },
   "husky": {
     "hooks": {

--- a/src/retrieveDailyPhoto.js
+++ b/src/retrieveDailyPhoto.js
@@ -3,10 +3,10 @@ const fetchPhotoFromNasa = require('./fetchPhotoFromNasa');
 async function retrieveDailyPhoto(request, response) {
     try {
         const data = await fetchPhotoFromNasa();
-    
+
         response.json(data);
-    } catch(error) {
-        response.json({
+    } catch (error) {
+        response.status(500).json({
             error: error.message
         })
     }

--- a/test/integration/dailyPhoto.int.test.js
+++ b/test/integration/dailyPhoto.int.test.js
@@ -1,0 +1,17 @@
+const supertest = require('supertest');
+const { createServer } = require('../../createServer');
+
+const server = createServer();
+const request = supertest(server);
+
+describe('GET /dailyPhoto', () => {
+    it('should return a 200 status code', async () => {
+        const response = await request.get('/dailyPhoto');
+
+        expect(response.status).toEqual(200);
+    });
+
+    it('should return the expected URL', () => {
+
+    });
+});

--- a/test/integration/dailyPhoto.int.test.js
+++ b/test/integration/dailyPhoto.int.test.js
@@ -16,25 +16,44 @@ describe('GET /dailyPhoto', () => {
         nock.enableNetConnect('127.0.0.1');
     });
 
-    beforeEach(() => {
-        process.env.NASA_API_KEY = 'fakeApiKey'
+    describe('when the request to the NASA API is successful', () => {
+        beforeEach(() => {
+            process.env.NASA_API_KEY = 'fakeApiKey'
 
-        nock('https://api.nasa.gov')
-            .get('/planetary/apod')
-            .query({ api_key: 'fakeApiKey' })
-            .reply(200, response);
+            nock('https://api.nasa.gov')
+                .get('/planetary/apod')
+                .query({ api_key: 'fakeApiKey' })
+                .reply(200, response);
+        });
+
+        it('should return a 200 status code', async () => {
+            const response = await request.get('/dailyPhoto');
+
+            expect(response.status).toEqual(200);
+        });
+
+        it('should return the expected URL', async () => {
+            const response = await request.get('/dailyPhoto');
+            const { url } = response.body;
+
+            expect(url).toEqual(expectedUrl);
+        });
     });
 
-    it('should return a 200 status code', async () => {
-        const response = await request.get('/dailyPhoto');
+    describe('when the request to the NASA API is unsuccessful', () => {
+        beforeEach(() => {
+            process.env.NASA_API_KEY = 'fakeApiKey'
 
-        expect(response.status).toEqual(200);
-    });
+            nock('https://api.nasa.gov')
+                .get('/planetary/apod')
+                .query({ api_key: 'fakeApiKey' })
+                .reply(500, response);
+        });
 
-    it('should return the expected URL', async () => {
-        const response = await request.get('/dailyPhoto');
-        const { url } = response.body;
+        it('should return a 500 status code', async () => {
+            const response = await request.get('/dailyPhoto');
 
-        expect(url).toEqual(expectedUrl);
+            expect(response.status).toEqual(500);
+        });
     });
 });

--- a/test/integration/dailyPhoto.int.test.js
+++ b/test/integration/dailyPhoto.int.test.js
@@ -1,17 +1,40 @@
 const supertest = require('supertest');
 const { createServer } = require('../../createServer');
+const nock = require('nock');
 
 const server = createServer();
 const request = supertest(server);
 
 describe('GET /dailyPhoto', () => {
+    const expectedUrl = 'https://nasa.com/apod/image';
+    const response = {
+        url: expectedUrl
+    }
+
+    beforeAll(() => {
+        nock.disableNetConnect();
+        nock.enableNetConnect('127.0.0.1');
+    });
+
+    beforeEach(() => {
+        process.env.NASA_API_KEY = 'fakeApiKey'
+
+        nock('https://api.nasa.gov')
+            .get('/planetary/apod')
+            .query({ api_key: 'fakeApiKey' })
+            .reply(200, response);
+    });
+
     it('should return a 200 status code', async () => {
         const response = await request.get('/dailyPhoto');
 
         expect(response.status).toEqual(200);
     });
 
-    it('should return the expected URL', () => {
+    it('should return the expected URL', async () => {
+        const response = await request.get('/dailyPhoto');
+        const { url } = response.body;
 
+        expect(url).toEqual(expectedUrl);
     });
 });

--- a/test/unit/fetchPhotoFromNasa.test.js
+++ b/test/unit/fetchPhotoFromNasa.test.js
@@ -1,4 +1,4 @@
-const fetchPhotoFromNasa = require("../src/fetchPhotoFromNasa");
+const fetchPhotoFromNasa = require("../../src/fetchPhotoFromNasa");
 const got = require("got");
 
 jest.mock('got');

--- a/test/unit/retrieveDailyPhoto.test.js
+++ b/test/unit/retrieveDailyPhoto.test.js
@@ -1,7 +1,7 @@
-const retrieveDailyPhoto = require('../src/retrieveDailyPhoto');
-const fetchPhotoFromNasa = require('../src/fetchPhotoFromNasa');
+const retrieveDailyPhoto = require('../../src/retrieveDailyPhoto');
+const fetchPhotoFromNasa = require('../../src/fetchPhotoFromNasa');
 
-jest.mock('../src/fetchPhotoFromNasa');
+jest.mock('../../src/fetchPhotoFromNasa');
 
 describe('Middleware - retrieveDailyPhoto', () => {
     it('should respond with JSON', async () => {

--- a/test/unit/retrieveDailyPhoto.test.js
+++ b/test/unit/retrieveDailyPhoto.test.js
@@ -38,8 +38,7 @@ describe('Middleware - retrieveDailyPhoto', () => {
     it('should call fetchPhotoFromNasa', async () => {
         const fakeRequest = {};
         const fakeResponse = {
-            json: jest.fn(),
-            status: jest.fn()
+            json: jest.fn()
         }
 
         await retrieveDailyPhoto(fakeRequest, fakeResponse);
@@ -65,9 +64,9 @@ describe('Middleware - retrieveDailyPhoto', () => {
 
     it('should respond with an error', async () => {
         const fakeRequest = {};
-        const fakeJson = jest.fn();
         const fakeResponse = {
-            status: jest.fn().mockReturnValue({ json: fakeJson })
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
         }
 
         const givenError = new Error('no photo for you today');
@@ -80,6 +79,6 @@ describe('Middleware - retrieveDailyPhoto', () => {
 
         await retrieveDailyPhoto(fakeRequest, fakeResponse);
 
-        expect(fakeJson).toHaveBeenCalledWith(expectedErrorData);
+        expect(fakeResponse.json).toHaveBeenCalledWith(expectedErrorData);
     });
 });

--- a/test/unit/retrieveDailyPhoto.test.js
+++ b/test/unit/retrieveDailyPhoto.test.js
@@ -38,7 +38,8 @@ describe('Middleware - retrieveDailyPhoto', () => {
     it('should call fetchPhotoFromNasa', async () => {
         const fakeRequest = {};
         const fakeResponse = {
-            json: jest.fn()
+            json: jest.fn(),
+            status: jest.fn()
         }
 
         await retrieveDailyPhoto(fakeRequest, fakeResponse);
@@ -51,7 +52,6 @@ describe('Middleware - retrieveDailyPhoto', () => {
         const fakeResponse = {
             json: jest.fn()
         }
-        
         const expectedData = {
             url: "https://www.nasa.gov/image.jpg"
         }
@@ -65,20 +65,21 @@ describe('Middleware - retrieveDailyPhoto', () => {
 
     it('should respond with an error', async () => {
         const fakeRequest = {};
+        const fakeJson = jest.fn();
         const fakeResponse = {
-            json: jest.fn()
+            status: jest.fn().mockReturnValue({ json: fakeJson })
         }
-        
+
         const givenError = new Error('no photo for you today');
 
         const expectedErrorData = {
             error: givenError.message
         }
-    
+
         fetchPhotoFromNasa.mockRejectedValue(givenError);
 
         await retrieveDailyPhoto(fakeRequest, fakeResponse);
 
-        expect(fakeResponse.json).toHaveBeenCalledWith(expectedErrorData);
+        expect(fakeJson).toHaveBeenCalledWith(expectedErrorData);
     });
 });

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -1,6 +1,6 @@
 const express = require('express');
-const retrieveDailyPhoto = require('../src/retrieveDailyPhoto.js');
-const createRoutes = require('../src/routes.js');
+const retrieveDailyPhoto = require('../../src/retrieveDailyPhoto.js');
+const createRoutes = require('../../src/routes.js');
 
 jest.mock('express');
 


### PR DESCRIPTION
**Changes**
- Add integration tests for /dailyPhoto endpoint using nock and supertest
- Move test files to dedicated directories
- Respond with `500` status code when the call to `retrieveDailyPhoto` is unsuccessful